### PR TITLE
Updated "Tested up to" after testing with WP 6.7.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: yaroslavborodii, max10110
 Donate link: https://jdi.company
 Tags: Smart Phone Addon, Ninja Forms, SPN, intlTelInput, International Telephone Input
 Requires at least: 6.0
-Tested up to: 6.5.4
+Tested up to: 6.7.1
 Stable tag: 1.3.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Tested with WordPress v6.7.1, went through all the functions, they work as described in the rhyme. `Up to` WordPress version was dumped to v6.7.1.